### PR TITLE
Issue 3 restrict mintable token ids

### DIFF
--- a/contracts/membership-nfts/minting/ERC1155KnownTokens/ERC1155KnownTokens.sol
+++ b/contracts/membership-nfts/minting/ERC1155KnownTokens/ERC1155KnownTokens.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+abstract contract ERC1155KnownTokens is Ownable, ERC1155 {
+    mapping(uint256 => string) private _tokens;
+    uint256 private _totalTokens;
+
+    function tokens() public view virtual returns(string[] memory) {
+        string[] memory nftsList = new string[](_totalTokens);
+
+        for (uint256 i = 0; i < _totalTokens; i++) {
+            nftsList[i] = _tokens[i + 1];
+        }
+
+        return nftsList;
+    }
+
+    function addToken(string calldata tokenName) public virtual onlyOwner returns(uint256 newTokenId) {
+        _totalTokens += 1;
+
+        uint newNFTId = _totalTokens;
+
+        _tokens[newNFTId] = tokenName;
+
+        return newNFTId;
+    }
+
+    function isTokenKnown(string calldata tokenName) public view virtual returns(bool isTokenApproved, uint256 tokenId) {
+        bytes32 tokenNameInBytes = keccak256(abi.encodePacked(tokenName));
+
+        for (uint256 i = 1; i <= _totalTokens; i++) {
+            string memory currentTokenName = _tokens[i];
+
+            if (keccak256(abi.encodePacked(currentTokenName)) == tokenNameInBytes) {
+                return (true, i);
+            }
+        }
+
+        return (false, 0);
+    }
+
+    function _beforeTokenTransfer(
+        address operator,
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) internal virtual override {
+        // CURRENT STATUS:
+        // operator -> no restriction
+        // from -> from must be address(0)
+        // to -> no restriction
+        // ids -> must be a known id
+        // amount -> no restriction
+
+        // Perform checks only when minting token
+        // token is being minted if "from" is zero address
+        if (from == address(0)) {
+            
+            for (uint256 i = 0; i < ids.length; i++) {
+                uint256 tokenId = ids[i];
+
+                // If token name is not valid, throw error
+                require(bytes(_tokens[tokenId]).length > 0, "ERC1155KnownTokens: Unknown TokenId");
+            }
+        }
+
+        super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
+    }
+
+}

--- a/contracts/membership-nfts/minting/ERC1155KnownTokens/ERC1155KnownTokens.test.ts
+++ b/contracts/membership-nfts/minting/ERC1155KnownTokens/ERC1155KnownTokens.test.ts
@@ -1,0 +1,88 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { BigNumber } from "ethers";
+
+describe("ERC1155KnownTokens", () => {
+  describe("Transactions", () => {
+    let ERC1155KnownTokensWrapperFactory: any;
+    let ERC1155KnownTokensWrapper: any;
+    let add1: SignerWithAddress;
+
+    beforeEach(async () => {
+      const signers = await ethers.getSigners();
+      add1 = signers[1];
+
+      ERC1155KnownTokensWrapperFactory = await ethers.getContractFactory(
+        "ERC1155KnownTokens_Wrapper"
+      );
+
+      ERC1155KnownTokensWrapper =
+        await ERC1155KnownTokensWrapperFactory.deploy();
+
+      await ERC1155KnownTokensWrapper.deployed();
+    });
+
+    it("Should give all approved tokens", async () => {
+      expect(await ERC1155KnownTokensWrapper.tokens()).to.deep.equal([]);
+
+      const tokenNames = ["TestToken1", "TestToken2"];
+
+      for await (const tokenName of tokenNames) {
+        const firstTxn = await ERC1155KnownTokensWrapper.addToken(tokenName);
+
+        await firstTxn.wait();
+      }
+
+      expect(await ERC1155KnownTokensWrapper.tokens()).to.deep.equal(
+        tokenNames
+      );
+    });
+
+    it("Should revert `_beforeTokenTransfer` transaction, when called with unapproved token", async () => {
+      await expect(
+        ERC1155KnownTokensWrapper.beforeTokenTransfer(
+          ethers.constants.AddressZero,
+          add1.address,
+          [1],
+          [100]
+        )
+      ).to.be.revertedWith("ERC1155KnownTokens: Unknown TokenId");
+
+      const txn = await ERC1155KnownTokensWrapper.addToken("TestToken");
+
+      await txn.wait();
+
+      await expect(
+        ERC1155KnownTokensWrapper.beforeTokenTransfer(
+          ethers.constants.AddressZero,
+          add1.address,
+          [1],
+          [100]
+        )
+      ).not.to.be.revertedWith("ERC1155KnownTokens: Unknown TokenId");
+    });
+
+    describe("Token Approval", () => {
+      it("Should approve a token", async () => {
+        const tokenName = "TestToken";
+
+        await ERC1155KnownTokensWrapper.addToken(tokenName);
+
+        const [isTokenKnown, tokenId]: [boolean, BigNumber] =
+          await ERC1155KnownTokensWrapper.isTokenKnown(tokenName);
+
+        expect(isTokenKnown).to.equal(true);
+        expect(tokenId.eq(1)).to.equal(true);
+      });
+
+      it("Should not approve a token, if called by non-owner", async () => {
+        const tokenName = "TestToken";
+
+        await expect(
+          ERC1155KnownTokensWrapper.connect(add1).addToken(tokenName)
+        ).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+  });
+});

--- a/contracts/membership-nfts/minting/ERC1155KnownTokens/ERC1155KnownTokens_Wrapper.sol
+++ b/contracts/membership-nfts/minting/ERC1155KnownTokens/ERC1155KnownTokens_Wrapper.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+import "./ERC1155KnownTokens.sol";
+
+contract ERC1155KnownTokens_Wrapper is ERC1155(""), ERC1155KnownTokens {
+    function _beforeTokenTransfer(
+        address operator,
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) internal override(ERC1155, ERC1155KnownTokens) {
+        super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
+    }
+
+    function beforeTokenTransfer(address from, address to, uint256[] calldata ids, uint256[] calldata amounts) public virtual {
+        _beforeTokenTransfer(_msgSender(), from, to, ids, amounts, "");
+    }
+}

--- a/contracts/membership-nfts/minting/ERC1155URIStorage/ERC1155URIStorage.sol
+++ b/contracts/membership-nfts/minting/ERC1155URIStorage/ERC1155URIStorage.sol
@@ -23,7 +23,7 @@ abstract contract ERC1155URIStorage is ERC1155 {
     }
 
     function _setURI(uint tokenId, string memory tokenURI) internal virtual {
-        require(bytes(tokenURI).length > 0, "Invalid tokenURI");
+        require(bytes(tokenURI).length > 0, "URIStorage: Invalid tokenURI");
 
         _tokenURIs[tokenId] = tokenURI;
 

--- a/contracts/membership-nfts/minting/ERC1155URIStorage/ERC1155URIStorage.test.ts
+++ b/contracts/membership-nfts/minting/ERC1155URIStorage/ERC1155URIStorage.test.ts
@@ -53,7 +53,7 @@ describe("ERC1155URIStorage", () => {
       const invalidURI = "";
 
       await expect(uriStorage.setURI(0, invalidURI)).to.be.revertedWith(
-        "Invalid tokenURI"
+        "URIStorage: Invalid tokenURI"
       );
     });
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
+import "hardhat-watcher";
 
 dotenv.config();
 
@@ -40,6 +41,11 @@ const config: HardhatUserConfig = {
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,
+  },
+  watcher: {
+    test: {
+      tasks: ["test"],
+    },
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "test": "export TEST_DIR=./contracts && hardhat test"
+    "test": "export TEST_DIR=./contracts && hardhat watch test"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",
@@ -33,6 +33,7 @@
     "ethers": "^5.0.0",
     "hardhat": "^2.9.3",
     "hardhat-gas-reporter": "^1.0.4",
+    "hardhat-watcher": "^2.3.0",
     "prettier": "^2.3.2",
     "prettier-plugin-solidity": "^1.0.0-beta.13",
     "solhint": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "company-dao-solidity",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2553,7 +2553,7 @@ chokidar@3.3.0:
   optionalDependencies:
     fsevents "~2.1.1"
 
-chokidar@3.5.3, chokidar@^3.4.0:
+chokidar@3.5.3, chokidar@^3.4.0, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -4997,6 +4997,13 @@ hardhat-gas-reporter@^1.0.4:
     array-uniq "1.0.3"
     eth-gas-reporter "^0.2.24"
     sha1 "^1.1.1"
+
+hardhat-watcher@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/hardhat-watcher/-/hardhat-watcher-2.3.0.tgz#57586a7fb79b73365014794f7e3dc0706aa65b7d"
+  integrity sha512-u76a/1pxPyW9DRZ7FZ8HoSQ4AuKOiSDQTR2NyiZlH5f0Ux+qQfahsh9CNusRLhx2s1OWzlkwCVvrdHq5FTGUzw==
+  dependencies:
+    chokidar "^3.5.3"
 
 hardhat@^2.9.3:
   version "2.9.3"


### PR DESCRIPTION
Closes #3 

- Added ERC1155KnownTokens contract to track approved & mintable token names and ids
- Added unit test cases for ERC1155KnownTokens contract
- Added ERC1155KnownTokens_Wrapper contract to interact with ERC1155KnownTokens contract while testing
- Added "URIStorage" context in require message of _setURI function of ERC1155URIStorage contract
- Upgraded node engine version to use "for await" loop.
- Added "hardhat-watcher" to watch file changes and run tests when file changes